### PR TITLE
Add onRunAsWorker hook to transports

### DIFF
--- a/docs-site/src/content/docs/transports.md
+++ b/docs-site/src/content/docs/transports.md
@@ -40,6 +40,7 @@ abstract class Transport<Levels extends Record<string, number>, Options extends 
   protected abstract flush(): void;
   protected abstract doFlushAndWait(): Promise<void>;
   protected abstract doClose(): Promise<void>;
+  protected abstract onRunAsWorker(): void;
 
   // Worker‑thread support, error handling, stats, etc.
 }
@@ -130,11 +131,12 @@ class FileTransport<Levels> extends Transport<Levels, FileTransportOptions<Level
   constructor(levelDef, opts) { … }
 
   protected doLog(log: Log<Levels>): void { queue & batch }
-  protected startFlushTimer(): boolean { … }
+  protected startFlushTimer(): void { … }
   protected stopFlushTimer(): void { … }
   protected flush(): void { /* write buffered batch */ }
   protected async doFlushAndWait(): Promise<void> { /* wait until flush completes */ }
   protected async doClose(): Promise<void> { /* flush & close streams */ }
+  protected onRunAsWorker(): void { /* stop timer */ }
   protected format(batch: Log<Levels>[]): string { JSON or printer output }
 }
 ```
@@ -170,12 +172,13 @@ class HttpTransport<Levels> extends Transport<Levels, HttpTransportOptions<Level
   constructor(levelDef, opts) { … }
 
   protected doLog(log: Log<Levels>): void { buffer.push(log); }
-  protected startFlushTimer(): boolean { … }
+  protected startFlushTimer(): void { … }
   protected stopFlushTimer(): void { … }
   protected flush(): void { this.sendBatch(buffered) }
   protected async doFlushAndWait(): Promise<void> { /* await in‑flight requests */ }
   protected async doClose(): Promise<void> { /* flush & wait */ }
   protected async sendBatch(batch: Log<Levels>[]): Promise<void> { /* HTTP call */ }
+  protected onRunAsWorker(): void { /* stop timer */ }
   protected format(batch: Log<Levels>): string|Buffer { JSON or NDJSON }
 }
 ```

--- a/packages/logpot/src/transports/consoleTransport.ts
+++ b/packages/logpot/src/transports/consoleTransport.ts
@@ -99,4 +99,6 @@ export class ConsoleTransport<
   }
 
   protected async doClose(): Promise<void> {}
+
+  protected onRunAsWorker() {}
 }

--- a/packages/logpot/src/transports/fileTransport.ts
+++ b/packages/logpot/src/transports/fileTransport.ts
@@ -148,10 +148,9 @@ export class FileTransport<
    *
    */
   protected startFlushTimer() {
-    if (this.hasWorker) return
+    if (this.flushTimer) return
     this.flushTimer = setInterval(() => {
-      if (this.hasWorker) this.stopFlushTimer()
-      else this.flush()
+      this.flush()
     }, this.options.flushInterval)
   }
 
@@ -159,7 +158,10 @@ export class FileTransport<
    * Stops the periodic flush timer.
    */
   protected stopFlushTimer() {
-    if (this.flushTimer) clearInterval(this.flushTimer)
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer)
+      this.flushTimer = undefined
+    }
   }
 
   /**
@@ -257,6 +259,10 @@ export class FileTransport<
   protected async doClose(): Promise<void> {
     this.stopFlushTimer()
     await this.closeStream()
+  }
+
+  protected onRunAsWorker() {
+    this.stopFlushTimer()
   }
 
   private openStream() {

--- a/packages/logpot/src/transports/httpTransport.ts
+++ b/packages/logpot/src/transports/httpTransport.ts
@@ -133,10 +133,9 @@ export class HttpTransport<
    * Starts the automatic flush timer if not managed by a worker.
    */
   protected startFlushTimer() {
-    if (this.hasWorker) return
+    if (this.flushTimer) return
     this.flushTimer = setInterval(() => {
-      if (this.hasWorker) this.stopFlushTimer()
-      else this.flush()
+      this.flush()
     }, this.options.flushInterval)
   }
 
@@ -144,7 +143,10 @@ export class HttpTransport<
    * Stops the automatic flush timer.
    */
   protected stopFlushTimer() {
-    if (this.flushTimer) clearInterval(this.flushTimer)
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer)
+      this.flushTimer = undefined
+    }
   }
 
   /**
@@ -232,6 +234,10 @@ export class HttpTransport<
    * Cleans up transport by stopping the flush timer.
    */
   protected async doClose(): Promise<void> {
+    this.stopFlushTimer()
+  }
+
+  protected onRunAsWorker() {
     this.stopFlushTimer()
   }
 }

--- a/packages/logpot/src/transports/transport.ts
+++ b/packages/logpot/src/transports/transport.ts
@@ -210,6 +210,8 @@ export abstract class Transport<
 
   protected abstract flush(): void
 
+  protected abstract onRunAsWorker(): void | Promise<void>
+
   protected formatter: Formatter<Levels>
 
   constructor(
@@ -478,6 +480,7 @@ export abstract class Transport<
       }),
       'ready'
     )
+    await this.onRunAsWorker()
   }
 
   private assertStats() {


### PR DESCRIPTION
## Summary
- introduce `onRunAsWorker` abstract method in `Transport`
- stop flush timers via the hook in `FileTransport` and `HttpTransport`
- no-op implementation for `ConsoleTransport`
- adjust worker tests and documentation

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6886b7258ab08328b537d59511d42295