### PR TITLE
feat(printer): add HTML colorizer

### DIFF
--- a/docs-site/src/content/docs/formatting.md
+++ b/docs-site/src/content/docs/formatting.md
@@ -20,6 +20,19 @@ type ColorOrColorizer = string | Colorizer
 - **ColorOrColorizer**
   Either a **space‑separated string** of style tokens _or_ your own transformer.
 
+### colorizeHTML
+
+Colorize small HTML fragments for terminal display.
+
+```ts
+import { colorizeHTML } from '@logpot/printer'
+
+console.log(colorizeHTML('<span class="tag">Hi</span>'))
+```
+
+Pass `{ tag, attrKey, attrValue, attrEq, content }` options to override the
+default colors.
+
 ## Theme Configuration
 
 ### ColorConfig & LogPotColorConfig

--- a/docs-site/src/content/docs/formatting.md
+++ b/docs-site/src/content/docs/formatting.md
@@ -30,8 +30,8 @@ import { colorizeHTML } from '@logpot/printer'
 console.log(colorizeHTML('<span class="tag">Hi</span>'))
 ```
 
-Pass `{ tag, attrKey, attrValue, attrEq, content }` options to override the
-default colors.
+Pass a configuration object `{ tag, attrKey, attrValue, attrEq, content }` to
+override the default colors.
 
 ## Theme Configuration
 

--- a/packages/printer/README.md
+++ b/packages/printer/README.md
@@ -65,6 +65,21 @@ console.log(
         custom))
 ```
 
+### Colorize HTML snippets
+
+```ts
+import { colorizeHTML } from '@logpot/printer'
+
+const html = '<div class="greet" data-id="1">Hello</div>'
+console.log(colorizeHTML(html))
+```
+
+Override default colors by passing options:
+
+```ts
+colorizeHTML(html, { tag: 'green', attrKey: 'magenta' })
+```
+
 ---
 
 ## 📚 Documentation & Community

--- a/packages/printer/README.md
+++ b/packages/printer/README.md
@@ -74,7 +74,7 @@ const html = '<div class="greet" data-id="1">Hello</div>'
 console.log(colorizeHTML(html))
 ```
 
-Override default colors by passing options:
+Override default colors by passing config:
 
 ```ts
 colorizeHTML(html, { tag: 'green', attrKey: 'magenta' })

--- a/packages/printer/src/colorizeHTML.ts
+++ b/packages/printer/src/colorizeHTML.ts
@@ -1,0 +1,75 @@
+import { type ColorOrColorizer, toColorizer } from './consoleColor'
+
+/**
+ * Options to customize {@link colorizeHTML}.
+ *
+ * Every field accepts either a colorizer function or a space separated list
+ * of ANSI style tokens that will be converted to a colorizer function using
+ * {@link toColorizer}.
+ */
+export interface ColorizeOptions {
+  /** Color applied to non-tag content. */
+  content?: ColorOrColorizer
+  /** Color for tag names and their brackets. */
+  tag?: ColorOrColorizer
+  /** Color for attribute keys. */
+  attrKey?: ColorOrColorizer
+  /** Color for attribute values. */
+  attrValue?: ColorOrColorizer
+  /** Color for the equals sign between attribute key and value. */
+  attrEq?: ColorOrColorizer
+}
+
+/**
+ * Colorize an HTML snippet for console output.
+ *
+ * The function performs a very small amount of parsing using regular
+ * expressions and wraps different parts of the HTML string with ANSI
+ * colors. It is not a full HTML parser but works well for debugging
+ * or visualising small fragments.
+ *
+ * @param html - raw HTML string to colorize.
+ * @param options - optional {@link ColorizeOptions} to override defaults.
+ * @returns the ANSI colored HTML string.
+ *
+ * @example
+ * ```ts
+ * import { colorizeHTML } from '@logpot/printer'
+ *
+ * console.log(colorizeHTML('<div class="greet">Hi</div>'))
+ * ```
+ */
+export function colorizeHTML(
+  html: string,
+  options: ColorizeOptions = {},
+): string {
+  const {
+    content: contentOption = '#b40657',
+    tag: tagColorOption = '#106767',
+    attrKey: attrKeyColorOption = 'cyan',
+    attrValue: attrValueColorOption = 'yellow',
+    attrEq: attrEqColorOption = 'gray',
+  } = options
+  const content = toColorizer(contentOption)
+  const tagColor = toColorizer(tagColorOption)
+  const attrKeyColor = toColorizer(attrKeyColorOption)
+  const attrValueColor = toColorizer(attrValueColorOption)
+  const attrEqColor = toColorizer(attrEqColorOption)
+  return content(
+    html
+      // Color the opening delimiter, optional slash, and tag name together.
+      .replace(/(&lt;|<)(\/?)([!a-zA-Z0-9:-]+)/g, (_, lt, slash, tag) => {
+        return tagColor(`${lt}${slash}${tag}`)
+      })
+      // Attribute key and equals
+      .replace(/([a-zA-Z-]+)(=)/g, (_, attr, eq) => {
+        return attrKeyColor(attr) + attrEqColor(eq)
+      })
+      // Attribute values, both single and double quoted
+      .replace(/("([^"\\]|\\.)*"|'([^'\\]|\\.)*')/g, (m) => {
+        return attrValueColor(m)
+      })
+      // Closing bracket or self-close
+      .replace(/(\/?>)/g, (m) => tagColor(m)),
+  )
+}

--- a/packages/printer/src/colorizeHTML.ts
+++ b/packages/printer/src/colorizeHTML.ts
@@ -1,13 +1,13 @@
 import { type ColorOrColorizer, toColorizer } from './consoleColor'
 
 /**
- * Options to customize {@link colorizeHTML}.
+ * Configuration options to customize {@link colorizeHTML}.
  *
  * Every field accepts either a colorizer function or a space separated list
  * of ANSI style tokens that will be converted to a colorizer function using
  * {@link toColorizer}.
  */
-export interface ColorizeOptions {
+export interface ColorizeHTMLConfig {
   /** Color applied to non-tag content. */
   content?: ColorOrColorizer
   /** Color for tag names and their brackets. */
@@ -29,7 +29,7 @@ export interface ColorizeOptions {
  * or visualising small fragments.
  *
  * @param html - raw HTML string to colorize.
- * @param options - optional {@link ColorizeOptions} to override defaults.
+ * @param config - optional {@link ColorizeHTMLConfig} to override defaults.
  * @returns the ANSI colored HTML string.
  *
  * @example
@@ -41,7 +41,7 @@ export interface ColorizeOptions {
  */
 export function colorizeHTML(
   html: string,
-  options: ColorizeOptions = {},
+  config: ColorizeHTMLConfig = {},
 ): string {
   const {
     content: contentOption = '#b40657',
@@ -49,7 +49,7 @@ export function colorizeHTML(
     attrKey: attrKeyColorOption = 'cyan',
     attrValue: attrValueColorOption = 'yellow',
     attrEq: attrEqColorOption = 'gray',
-  } = options
+  } = config
   const content = toColorizer(contentOption)
   const tagColor = toColorizer(tagColorOption)
   const attrKeyColor = toColorizer(attrKeyColorOption)

--- a/packages/printer/src/index.ts
+++ b/packages/printer/src/index.ts
@@ -1,5 +1,5 @@
 export { type ColorConfig, normalize } from './colorConfig'
-export { colorizeHTML, type ColorizeOptions } from './colorizeHTML'
+export { colorizeHTML, type ColorizeHTMLConfig } from './colorizeHTML'
 export {
   type Colorizer,
   type ColorOrColorizer,

--- a/packages/printer/src/index.ts
+++ b/packages/printer/src/index.ts
@@ -1,4 +1,5 @@
 export { type ColorConfig, normalize } from './colorConfig'
+export { colorizeHTML, type ColorizeOptions } from './colorizeHTML'
 export {
   type Colorizer,
   type ColorOrColorizer,


### PR DESCRIPTION
## Summary
- add `colorizeHTML` helper with configurable colors for tags, attributes and content
- export the new function from the printer package
- document HTML colorizer usage

## Testing
- `yarn workspace @logpot/printer lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688db79aefc08328b17291db273ed767