### PR TITLE
feat(printer): track object key path

### DIFF
--- a/packages/printer/src/formatters/arrayFormatter.test.ts
+++ b/packages/printer/src/formatters/arrayFormatter.test.ts
@@ -23,6 +23,7 @@ const makeCtx = (
     colorConfig: colorlessConfig,
     seen: new WeakSet(),
     quotes: '"',
+    keys: [],
     prefix: '',
   }
 }

--- a/packages/printer/src/formatters/objectFormatter.test.ts
+++ b/packages/printer/src/formatters/objectFormatter.test.ts
@@ -23,6 +23,7 @@ const makeCtx = (
     colorConfig: colorlessConfig,
     seen: new WeakSet(),
     quotes: '"',
+    keys: [],
     prefix: '',
   }
 }
@@ -117,5 +118,21 @@ b: 2`)
     expect(out.endsWith('}')).toBe(false)
     // Entries still present
     expect(out).toContain('"a": 1')
+  })
+
+  it('tracks keys in context during formatting', () => {
+    const ctx = makeCtx()
+    const recorder: string[] = []
+    const numberFormatter = {
+      canFormat: (value: unknown) => typeof value === 'number',
+      format: (value: unknown, ctx: PrintContext, _printer: Printer) => {
+        recorder.push(ctx.keys.join('.'))
+        return String(value)
+      },
+    }
+    const printer = new Printer([new ObjectFormatter(), numberFormatter])
+    printer.print({ a: { b: 1 }, c: 2 }, ctx)
+    expect(recorder).toEqual(['a.b', 'c'])
+    expect(ctx.keys).toEqual([])
   })
 })

--- a/packages/printer/src/formatters/objectFormatter.test.ts
+++ b/packages/printer/src/formatters/objectFormatter.test.ts
@@ -125,7 +125,7 @@ b: 2`)
     const recorder: string[] = []
     const numberFormatter = {
       canFormat: (value: unknown) => typeof value === 'number',
-      format: (value: unknown, ctx: PrintContext, _printer: Printer) => {
+      format: (value: unknown, ctx: PrintContext) => {
         recorder.push(ctx.keys.join('.'))
         return String(value)
       },

--- a/packages/printer/src/formatters/objectFormatter.ts
+++ b/packages/printer/src/formatters/objectFormatter.ts
@@ -48,9 +48,12 @@ export class ObjectFormatter implements IFormatter {
     const orgIndent = ctx.indent
     ctx.indent += ' '.repeat(orgPrefix.length)
     ctx.prefix = ''
-    const entries = displayed.map((k) =>
-      getText(ctx, this.formatEntry(k, obj[k], ctx, printer))
-    )
+    const entries = displayed.map((k) => {
+      ctx.keys.push(k)
+      const entry = getText(ctx, this.formatEntry(k, obj[k], ctx, printer))
+      ctx.keys.pop()
+      return entry
+    })
 
     const remaining = ordered.length - displayed.length
     if (remaining > 0) {

--- a/packages/printer/src/print.ts
+++ b/packages/printer/src/print.ts
@@ -29,6 +29,7 @@ export function print(
     indentString,
     colorConfig: mergedColors,
     quotes: options?.quotes ?? '"',
+    keys: [],
     prefix: '',
   }
   return printer.print(value, ctx)

--- a/packages/printer/src/printContext.ts
+++ b/packages/printer/src/printContext.ts
@@ -41,6 +41,11 @@ export interface PrintContext {
   quotes: string
 
   /**
+   * Stack of object keys representing the current traversal path.
+   */
+  keys: string[]
+
+  /**
    * Prefix inserted before each line when printing multi-line values
    * (useful for nested or list items).
    */


### PR DESCRIPTION
## Summary
- support tracking object key paths via `PrintContext.keys`
- ensure `ObjectFormatter` pushes and pops keys while formatting
- test key path tracking

## Testing
- `yarn test packages/printer --run`


------
https://chatgpt.com/codex/tasks/task_e_688dbb4a77288328936a05441b18b035